### PR TITLE
Add command line argument parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 3
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +30,36 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "console"
@@ -56,6 +103,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,15 +143,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
 name = "moji"
 version = "0.0.2"
 dependencies = [
+ "clap",
  "console",
  "dialoguer",
 ]
@@ -83,6 +174,57 @@ name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -118,6 +260,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,10 +310,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"
@@ -162,6 +348,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 dialoguer = "0.10.0"
 console = "0.15.0"
+clap = { version = "3.0", features = ["derive"] }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,0 +1,134 @@
+use crate::PromptStyle;
+use clap::{ArgEnum, Parser};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use dialoguer::Confirm;
+use std::{env, io, fs};
+
+#[derive(Debug, Parser)]
+pub struct HookCli {
+    #[clap(arg_enum)]
+    pub hook: GitHook,
+}
+
+#[derive(ArgEnum, Clone, Debug)]
+pub enum GitHook {
+    /// A commit-msg hook that spell-checks emoji shortcodes
+    CommitMsg,
+    /// TODO
+    PreCommit,
+}
+
+impl GitHook {
+    fn as_str(&self) -> &'static str {
+        match self {
+            GitHook::CommitMsg => "commit-msg",
+            GitHook::PreCommit => "pre-commit",
+        }
+    }
+    fn as_path(&self) -> &Path {
+        Path::new(self.as_str())
+    }
+}
+
+pub fn try_add_git_hook(hook: GitHook, style: PromptStyle) {
+    let cwd = env::current_dir().unwrap();
+    if check_is_git_repo(&cwd) {
+        add_git_hook(hook, &cwd, &style).unwrap();
+    } else {
+        eprintln!(
+            "{} is not a git repo!",
+            style.path.apply_to(cwd.to_str().unwrap())
+        );
+    }
+}
+
+fn check_is_git_repo(dir: &Path) -> bool {
+    dir.join(Path::new(".git")).exists()
+}
+
+fn add_git_hook(hook: GitHook, repo_root: &Path, style: &PromptStyle) -> io::Result<()> {
+    assert!(
+        matches!(hook, GitHook::CommitMsg),
+        "Only `commit-msg` hook is implemented!"
+    );
+    let hook_dir = Path::new(".git/hooks");
+    let hook_path = hook_dir.join(hook.as_path());
+    let full_hook_path = repo_root.join(&hook_path);
+    if ask_file_write(&full_hook_path, style).unwrap() {
+        write_hook_script(&hook, &full_hook_path)?;
+        println!(
+            "'{}' added to '{}'",
+            style.path.apply_to(hook.as_str()),
+            style.path.apply_to(hook_dir.to_str().unwrap()),
+        );
+        match fs::set_permissions(&hook_path, PermissionsExt::from_mode(0o770)) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                eprintln!("{}: {}", style.error.apply_to("[ERROR]:"), e);
+                let cmd = style
+                    .code
+                    .apply_to(format!("chmod +x {}", hook_path.display()));
+                println!("Run `{}` to set the script as executable", cmd);
+                Ok(())
+            }
+        }
+    } else {
+        Ok(())
+    }
+}
+
+/// Ask if a file can be written in a location
+///
+/// # Arguments
+/// * `target` Reference to Path slice to get permission to write to
+fn ask_file_write(target: &Path, style: &PromptStyle) -> Option<bool> {
+    // Ask if a user wants to overrite exiting file
+    if target.exists() {
+        println!(
+            "{} '{}' already exists!",
+            style.warning.apply_to("[WARNING]:"),
+            style.path.apply_to(target.display())
+        );
+        return Some(
+            Confirm::new()
+                .with_prompt(format!(
+                    "Do you want to overwrite it? {}",
+                    style.secondary.apply_to("(irreversible)")
+                ))
+                .default(false)
+                .interact()
+                .unwrap_or_default(),
+        );
+    }
+    // Check if target directory exists
+    let target_dir = target.parent()?;
+    if !target_dir.exists() {
+        println!(
+            "{} '{}' not found!",
+            style.error.apply_to("[ERROR]:"),
+            style.path.apply_to(target_dir.display())
+        );
+        return Some(false);
+    }
+    return Some(
+        Confirm::new()
+            .with_prompt(format!(
+                "Write '{}' to '{}'?",
+                style.path.apply_to(target.file_name()?.to_str()?),
+                style.path.apply_to(target.parent()?.display()),
+            ))
+            .default(false)
+            .interact()
+            .unwrap_or_default(),
+    );
+}
+
+/// Copy script into git hooks folder
+fn write_hook_script(hook: &GitHook, target: &Path) -> io::Result<()> {
+    let script: Result<&[u8], ()> = match hook {
+        GitHook::CommitMsg => Ok(include_bytes!("hooks/commit-msg.sh")),
+        _ => unimplemented!(),
+    };
+    fs::write(target, script.unwrap())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,16 @@
-use clap::{ArgEnum, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use console::{Emoji, Style};
-use dialoguer::Confirm;
-use std::io;
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
-use std::{env, fs, str};
+use std::str;
 
-/// A fictional versioning CLI
+mod hook;
+use crate::hook::HookCli;
+
 #[derive(Debug, Parser)]
 #[clap(name = "moji")]
 #[clap(about = "Emoji toolkit for developers")]
 struct Cli {
     #[clap(subcommand)]
     command: Option<Command>,
-}
-
-#[derive(Debug, Parser)]
-struct HookCli {
-    #[clap(arg_enum)]
-    hook: GitHook,
 }
 
 #[derive(Debug, Subcommand)]
@@ -31,28 +23,8 @@ enum Command {
     Hook(HookCli),
 }
 
-#[derive(ArgEnum, Clone, Debug)]
-enum GitHook {
-    /// A commit-msg hook that spell-checks emoji shortcodes
-    CommitMsg,
-    /// TODO
-    PreCommit,
-}
-
-impl GitHook {
-    fn as_str(&self) -> &'static str {
-        match self {
-            GitHook::CommitMsg => "commit-msg",
-            GitHook::PreCommit => "pre-commit",
-        }
-    }
-
-    fn as_path(&self) -> &Path {
-        Path::new(self.as_str())
-    }
-}
-
-struct PromptStyle {
+/// Styling for command line output
+pub struct PromptStyle {
     warning: Style,
     error: Style,
     path: Style,
@@ -60,7 +32,6 @@ struct PromptStyle {
     code: Style,
 }
 
-/// Add an emoji shortcode spell checker to your git repo
 fn main() {
     let args = Cli::parse();
     let style: PromptStyle = PromptStyle {
@@ -71,111 +42,11 @@ fn main() {
         code: Style::new().magenta(),
     };
     match args.command {
-        Some(Command::Hook(HookCli { hook })) => {
-            let cwd = env::current_dir().unwrap();
-            if check_is_git_repo(&cwd) {
-                add_git_hook(hook, &cwd, &style).unwrap();
-            } else {
-                eprintln!(
-                    "{} is not a git repo!",
-                    style.path.apply_to(cwd.to_str().unwrap())
-                );
-            }
-        }
+        Some(Command::Hook(HookCli { hook })) => hook::try_add_git_hook(hook, style),
         None => eprintln!(
             "{} Interactive search function not yet implemented {}",
             style.error.apply_to("[ERROR]:"),
             Emoji("\u{1F480}", "")
         ),
     };
-}
-
-fn check_is_git_repo(dir: &Path) -> bool {
-    dir.join(Path::new(".git")).exists()
-}
-
-fn add_git_hook(hook: GitHook, repo_root: &Path, style: &PromptStyle) -> io::Result<()> {
-    assert!(
-        matches!(hook, GitHook::CommitMsg),
-        "Only `commit-msg` hook is implemented!"
-    );
-    let hook_dir = Path::new(".git/hooks");
-    let hook_path = hook_dir.join(hook.as_path());
-    let full_hook_path = repo_root.join(&hook_path);
-    if ask_file_write(&full_hook_path, style).unwrap() {
-        write_hook_script(&hook, &full_hook_path)?;
-        println!(
-            "'{}' added to '{}'",
-            style.path.apply_to(hook.as_str()),
-            style.path.apply_to(hook_dir.to_str().unwrap()),
-        );
-        match fs::set_permissions(&hook_path, PermissionsExt::from_mode(0o770)) {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                eprintln!("{}: {}", style.error.apply_to("[ERROR]:"), e);
-                let cmd = style
-                    .code
-                    .apply_to(format!("chmod +x {}", hook_path.display()));
-                println!("Run `{}` to set the script as executable", cmd);
-                Ok(())
-            }
-        }
-    } else {
-        Ok(())
-    }
-}
-
-/// Ask if a file can be written in a location
-///
-/// # Arguments
-/// * `target` Reference to Path slice to get permission to write to
-fn ask_file_write(target: &Path, style: &PromptStyle) -> Option<bool> {
-    // Ask if a user wants to overrite exiting file
-    if target.exists() {
-        println!(
-            "{} '{}' already exists!",
-            style.warning.apply_to("[WARNING]:"),
-            style.path.apply_to(target.display())
-        );
-        return Some(
-            Confirm::new()
-                .with_prompt(format!(
-                    "Do you want to overwrite it? {}",
-                    style.secondary.apply_to("(irreversible)")
-                ))
-                .default(false)
-                .interact()
-                .unwrap_or_default(),
-        );
-    }
-    // Check if target directory exists
-    let target_dir = target.parent()?;
-    if !target_dir.exists() {
-        println!(
-            "{} '{}' not found!",
-            style.error.apply_to("[ERROR]:"),
-            style.path.apply_to(target_dir.display())
-        );
-        return Some(false);
-    }
-    return Some(
-        Confirm::new()
-            .with_prompt(format!(
-                "Write '{}' to '{}'?",
-                style.path.apply_to(target.file_name()?.to_str()?),
-                style.path.apply_to(target.parent()?.display()),
-            ))
-            .default(false)
-            .interact()
-            .unwrap_or_default(),
-    );
-}
-
-/// Copy script into git hooks folder
-fn write_hook_script(hook: &GitHook, target: &Path) -> io::Result<()> {
-    let script: Result<&[u8], ()> = match hook {
-        GitHook::CommitMsg => Ok(include_bytes!("hooks/commit-msg.sh")),
-        _ => unimplemented!(),
-    };
-    fs::write(target, script.unwrap())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use console::{Emoji, Style};
 use dialoguer::Confirm;
 use std::io;
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::{env, fs, str};
 
 /// A fictional versioning CLI
@@ -98,7 +98,7 @@ fn add_git_hook(hook: GitHook, repo_root: &Path, style: &PromptStyle) -> io::Res
     let hook_dir = Path::new(".git/hooks");
     let hook_path = hook_dir.join(hook.as_path());
     let full_hook_path = repo_root.join(&hook_path);
-    if ask_file_write(&full_hook_path, &hook_dir, &style).unwrap() {
+    if ask_file_write(&full_hook_path, hook_dir, style).unwrap() {
         write_hook_script(&hook_path)?;
         println!(
             "'{}' added to {}",
@@ -167,7 +167,7 @@ fn ask_file_write(rel_path: &Path, base_dir: &Path, style: &PromptStyle) -> Opti
 }
 
 /// Copy script into git hooks folder
-fn write_hook_script(target: &PathBuf) -> io::Result<()> {
+fn write_hook_script(target: &Path) -> io::Result<()> {
     // FIXME doesn't match to script type
     let script = include_bytes!("hooks/commit-msg.sh");
     fs::write(target, script)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,77 +1,174 @@
-use console::Style;
+use clap::{ArgEnum, Parser, Subcommand};
+use console::{Emoji, Style};
 use dialoguer::Confirm;
 use std::io;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::{env, fs};
+use std::{env, fs, str};
 
-/// Add an emoji shortcode spell checker to your git repo
-fn main() -> io::Result<()> {
-    let mut hook_dir = env::current_dir()?;
-    let hook_name = Path::new("commit-msg");
-    hook_dir.push(Path::new(".git/hooks"));
-    if ask(&hook_dir, hook_name) {
-        let hook_path = hook_dir.join(hook_name);
-        generate_hook(&hook_path).unwrap();
-        println!("'commit-msg' added to .git/hooks");
-        match fs::set_permissions(&hook_path, PermissionsExt::from_mode(0o770)) {
-            Ok(()) => (),
-            Err(e) => {
-                eprintln!("{}", e);
-                println!(
-                    "Run 'chmod +x {}' to set the script as executable",
-                    hook_path.display()
-                )
-            }
+/// A fictional versioning CLI
+#[derive(Debug, Parser)]
+#[clap(name = "moji")]
+#[clap(about = "Emoji toolkit for developers")]
+struct Cli {
+    #[clap(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Debug, Parser)]
+struct HookCli {
+    #[clap(arg_enum)]
+    hook: GitHook,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Add git hooks to help emojify your git repo
+    ///
+    /// Available hooks:
+    ///
+    /// `commit-msg` : spell check emoji shortcodes in your commit message
+    Hook(HookCli),
+}
+
+#[derive(ArgEnum, Clone, Debug)]
+enum GitHook {
+    /// A commit-msg hook that spell-checks emoji shortcodes
+    CommitMsg,
+    /// TODO
+    PreCommit,
+}
+
+impl GitHook {
+    fn as_str(&self) -> &'static str {
+        match self {
+            GitHook::CommitMsg => "commit-msg",
+            GitHook::PreCommit => "pre-commit",
         }
     }
-    Ok(())
+
+    fn as_path(&self) -> &Path {
+        Path::new(self.as_str())
+    }
+}
+
+struct PromptStyle {
+    warning: Style,
+    error: Style,
+    path: Style,
+    secondary: Style,
+    code: Style,
+}
+
+/// Add an emoji shortcode spell checker to your git repo
+fn main() {
+    let args = Cli::parse();
+    let style: PromptStyle = PromptStyle {
+        warning: Style::new().yellow().bold(),
+        error: Style::new().red().bold(),
+        path: Style::new().bright().blue(),
+        secondary: Style::new().dim(),
+        code: Style::new().magenta(),
+    };
+    match args.command {
+        Some(Command::Hook(HookCli { hook })) => {
+            let cwd = env::current_dir().unwrap();
+            if check_is_git_repo(&cwd) {
+                add_git_hook(hook, &cwd, &style).unwrap();
+            } else {
+                eprintln!(
+                    "{} is not a git repo!",
+                    style.path.apply_to(cwd.to_str().unwrap())
+                );
+            }
+        }
+        None => eprintln!(
+            "{} Interactive search function not yet implemented {}",
+            style.error.apply_to("[ERROR]:"),
+            Emoji("\u{1F480}", "")
+        ),
+    };
+}
+
+fn check_is_git_repo(dir: &Path) -> bool {
+    dir.join(Path::new(".git")).exists()
+}
+
+fn add_git_hook(hook: GitHook, repo_root: &Path, style: &PromptStyle) -> io::Result<()> {
+    let hook_dir = Path::new(".git/hooks");
+    let hook_path = hook_dir.join(hook.as_path());
+    let full_hook_path = repo_root.join(&hook_path);
+    if ask_file_write(&full_hook_path, &hook_dir, &style).unwrap() {
+        write_hook_script(&hook_path)?;
+        println!(
+            "'{}' added to {}",
+            style.path.apply_to(hook.as_str()),
+            style.path.apply_to(hook_dir.to_str().unwrap()),
+        );
+        match fs::set_permissions(&hook_path, PermissionsExt::from_mode(0o770)) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                eprintln!("{}: {}", style.error.apply_to("[ERROR]:"), e);
+                println!(
+                    "Run `{}` to set the script as executable",
+                    style
+                        .code
+                        .apply_to(format!("chmod +x {}", hook_path.display()))
+                );
+                Ok(())
+            }
+        }
+    } else {
+        Ok(())
+    }
 }
 
 /// Ask if a file can be written
-fn ask(dir: &Path, fname: &Path) -> bool {
-    let warn = Style::new().yellow().bold();
-    let error = Style::new().red().bold();
-    let dim = Style::new().dim();
-    let blue = Style::new().bright().blue();
-    if dir.join(fname).exists() {
+fn ask_file_write(rel_path: &Path, base_dir: &Path, style: &PromptStyle) -> Option<bool> {
+    let target = base_dir.join(rel_path);
+    // Ask if a user wants to overrite exiting file
+    if target.exists() {
         println!(
-            "{} '{}' hook already exists!",
-            warn.apply_to("[WARNING]:"),
-            blue.apply_to(fname.display())
+            "{} '{}' already exists!",
+            style.warning.apply_to("[WARNING]:"),
+            style.path.apply_to(rel_path.display())
         );
-        return Confirm::new()
+        return Some(
+            Confirm::new()
+                .with_prompt(format!(
+                    "Do you want to overwrite it? {}",
+                    style.secondary.apply_to("(irreversible)")
+                ))
+                .default(false)
+                .interact()
+                .unwrap_or_default(),
+        );
+    }
+    // Check if target directory exists
+    if !base_dir.exists() {
+        println!(
+            "{} '{}' not found!",
+            style.error.apply_to("[ERROR]:"),
+            style.error.apply_to(base_dir.display())
+        );
+        return Some(false);
+    }
+    return Some(
+        Confirm::new()
             .with_prompt(format!(
-                "Do you want to overwrite it? {}",
-                dim.apply_to("(irreversible)")
+                "Write '{}' to '{}' ",
+                style.path.apply_to(rel_path.file_name()?.to_str()?),
+                style.path.apply_to(rel_path.parent()?.display()),
             ))
             .default(false)
             .interact()
-            .unwrap_or_default();
-    }
-    // Check if parent folders exist
-    let parent = dir.parent().unwrap();
-    if !parent.exists() {
-        println!(
-            "{} '{}' not found!",
-            error.apply_to("[ERROR]:"),
-            parent.to_str().unwrap()
-        );
-        return false;
-    }
-    return Confirm::new()
-        .with_prompt(format!(
-            "Add '{}' script to '{}' ",
-            blue.apply_to(fname.display()),
-            blue.apply_to(".git/hooks"),
-        ))
-        .default(false)
-        .interact()
-        .unwrap_or_default();
+            .unwrap_or_default(),
+    );
 }
 
 /// Copy script into git hooks folder
-fn generate_hook(target: &PathBuf) -> io::Result<()> {
+fn write_hook_script(target: &PathBuf) -> io::Result<()> {
+    // FIXME doesn't match to script type
     let script = include_bytes!("hooks/commit-msg.sh");
     fs::write(target, script)
 }


### PR DESCRIPTION
Use CLAP to parse parse the optional subcommand `hook` and it's argument into a GitHook enumeration

FIXME: Currently doesn't use a different script for each git hook